### PR TITLE
Add games listing and session parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# cloudplay
+
+A minimal Go web server that will evolve into a cloud gaming service capable of running PS2 games. For now it exposes a few endpoints and serves as the project's starting point.
+
+## Building
+
+```bash
+go build
+```
+
+## Running
+
+```bash
+PORT=8080 go run .
+```
+
+The server listens on the port specified by the `PORT` environment variable (defaults to `8080`). It currently provides the following endpoints:
+
+- `/` – returns **Hello, world!**
+- `/health` – returns a JSON health status
+- `/session/start` – placeholder for starting a PS2 game session
+- `/games` – lists available games
+
+The `/session/start` endpoint now requires a `game` query parameter indicating
+which game to start.
+
+These endpoints will expand as the project grows toward streaming PS2 games through the cloud.

--- a/main.go
+++ b/main.go
@@ -1,7 +1,59 @@
-package cloudplay
+package main
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+// A small set of sample games that would be available for streaming.
+var games = []string{
+	"Gran Turismo 4",
+	"Final Fantasy X",
+	"Metal Gear Solid 3",
+}
+
+func setupRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, world!")
+	})
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	// List available games
+	mux.HandleFunc("/games", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string][]string{"games": games})
+	})
+
+	// Placeholder endpoint for starting a PS2 session
+	mux.HandleFunc("/session/start", func(w http.ResponseWriter, r *http.Request) {
+		game := r.URL.Query().Get("game")
+		if game == "" {
+			http.Error(w, "missing game parameter", http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintf(w, "Starting PS2 session for %s... (not implemented)\n", game)
+	})
+}
 
 func main() {
-	fmt.Println("Hello world")
+	mux := http.NewServeMux()
+	setupRoutes(mux)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	addr := ":" + port
+	log.Printf("Starting server on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthEndpoint(t *testing.T) {
+	mux := http.NewServeMux()
+	setupRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	expected := "{\"status\":\"ok\"}\n"
+	if w.Body.String() != expected {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestGamesEndpoint(t *testing.T) {
+	mux := http.NewServeMux()
+	setupRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/games", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	expected := "{\"games\":[\"Gran Turismo 4\",\"Final Fantasy X\",\"Metal Gear Solid 3\"]}\n"
+	if w.Body.String() != expected {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestSessionStart(t *testing.T) {
+	mux := http.NewServeMux()
+	setupRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/session/start?game=TestGame", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	expected := "Starting PS2 session for TestGame... (not implemented)\n"
+	if w.Body.String() != expected {
+		t.Fatalf("unexpected body: %s", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add `/games` endpoint with a hard-coded list
- require a `game` parameter for `/session/start`
- document new routes in the README
- expand tests for new endpoints

## Testing
- `go build -v .`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6848323a0300832e98a41a4030941c82