### PR TITLE
Implement agent scaffolding and simple endpoints

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+type Token struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+}
+
+type AuthenticationAgent interface {
+	Login(username, password string) (*Token, error)
+	Refresh(refreshToken string) (*Token, error)
+	Verify(accessToken string) (bool, error)
+}
+
+type SimpleAuth struct {
+	mu     sync.Mutex
+	tokens map[string]*Token
+}
+
+func NewSimpleAuth() *SimpleAuth {
+	return &SimpleAuth{tokens: make(map[string]*Token)}
+}
+
+func (s *SimpleAuth) Login(username, password string) (*Token, error) {
+	if username == "" || password == "" {
+		return nil, errors.New("missing credentials")
+	}
+	token := &Token{
+		AccessToken:  username + "_access",
+		RefreshToken: username + "_refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}
+	s.mu.Lock()
+	s.tokens[token.AccessToken] = token
+	s.mu.Unlock()
+	return token, nil
+}
+
+func (s *SimpleAuth) Refresh(refreshToken string) (*Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range s.tokens {
+		if t.RefreshToken == refreshToken {
+			t.AccessToken = t.AccessToken + "_new"
+			t.ExpiresAt = time.Now().Add(time.Hour)
+			return t, nil
+		}
+	}
+	return nil, errors.New("invalid refresh token")
+}
+
+func (s *SimpleAuth) Verify(accessToken string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.tokens[accessToken]
+	if !ok {
+		return false, nil
+	}
+	if time.Now().After(t.ExpiresAt) {
+		delete(s.tokens, accessToken)
+		return false, nil
+	}
+	return true, nil
+}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,23 @@
+package auth
+
+import "testing"
+
+func TestSimpleAuth(t *testing.T) {
+	a := NewSimpleAuth()
+	token, err := a.Login("user", "pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, err := a.Verify(token.AccessToken)
+	if err != nil || !ok {
+		t.Fatalf("verify failed: %v %v", ok, err)
+	}
+	oldToken := token.AccessToken
+	newToken, err := a.Refresh(token.RefreshToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newToken.AccessToken == oldToken {
+		t.Fatalf("expected new access token")
+	}
+}

--- a/input/input.go
+++ b/input/input.go
@@ -1,0 +1,13 @@
+package input
+
+// Processor handles incoming input frames.
+type Processor interface {
+	Handle(frame []byte) error
+}
+
+type DummyProcessor struct{}
+
+func (d DummyProcessor) Handle(frame []byte) error {
+	// stub
+	return nil
+}

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -1,0 +1,10 @@
+package input
+
+import "testing"
+
+func TestDummyProcessor(t *testing.T) {
+	var p Processor = DummyProcessor{}
+	if err := p.Handle([]byte("test")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,18 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
+
+	"cloudplay/auth"
+	"cloudplay/session"
+)
+
+var (
+	authAgent  auth.AuthenticationAgent
+	sessionMgr session.Manager
 )
 
 func setupRoutes(mux *http.ServeMux) {
@@ -18,13 +27,52 @@ func setupRoutes(mux *http.ServeMux) {
 		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 	})
 
-	// Placeholder endpoint for starting a PS2 session
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		var creds struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &creds)
+		token, err := authAgent.Login(creds.Username, creds.Password)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(token)
+	})
+
 	mux.HandleFunc("/session/start", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Starting PS2 session... (not implemented)")
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		ok, _ := authAgent.Verify(authHeader)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var req struct {
+			GameID string `json:"game_id"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &req)
+		s, err := sessionMgr.Start(req.GameID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(s)
 	})
 }
 
 func main() {
+	authAgent = auth.NewSimpleAuth()
+	sessionMgr = session.NewInMemoryManager()
+
 	mux := http.NewServeMux()
 	setupRoutes(mux)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"cloudplay/auth"
+	"cloudplay/session"
 )
 
 func TestHealthEndpoint(t *testing.T) {
+	authAgent = auth.NewSimpleAuth()
+	sessionMgr = session.NewInMemoryManager()
+
 	mux := http.NewServeMux()
 	setupRoutes(mux)
 
@@ -22,4 +30,34 @@ func TestHealthEndpoint(t *testing.T) {
 	if w.Body.String() != expected {
 		t.Fatalf("unexpected body: %s", w.Body.String())
 	}
+}
+
+func TestLoginAndStartSession(t *testing.T) {
+	authAgent = auth.NewSimpleAuth()
+	sessionMgr = session.NewInMemoryManager()
+
+	mux := http.NewServeMux()
+	setupRoutes(mux)
+
+	loginReq := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(`{"username":"u","password":"p"}`))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, loginReq)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login failed: %d", w.Code)
+	}
+	token := w.Body.String()
+
+	startReq := httptest.NewRequest(http.MethodPost, "/session/start", strings.NewReader(`{"game_id":"g"}`))
+	startReq.Header.Set("Authorization", structFromResponse(token))
+	w2 := httptest.NewRecorder()
+	mux.ServeHTTP(w2, startReq)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("start failed: %d", w2.Code)
+	}
+}
+
+func structFromResponse(body string) string {
+	var t auth.Token
+	json.Unmarshal([]byte(body), &t)
+	return t.AccessToken
 }

--- a/monitoring/monitor.go
+++ b/monitoring/monitor.go
@@ -1,0 +1,10 @@
+package monitoring
+
+// Monitor collects metrics and logs.
+type Monitor interface {
+	Record(event string) error
+}
+
+type DummyMonitor struct{}
+
+func (d DummyMonitor) Record(event string) error { return nil }

--- a/monitoring/monitor_test.go
+++ b/monitoring/monitor_test.go
@@ -1,0 +1,10 @@
+package monitoring
+
+import "testing"
+
+func TestDummyMonitor(t *testing.T) {
+	var m Monitor = DummyMonitor{}
+	if err := m.Record("event"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/network/transport.go
+++ b/network/transport.go
@@ -1,0 +1,12 @@
+package network
+
+// Transport routes media packets.
+type Transport interface {
+	Send(packet []byte) error
+}
+
+type DummyTransport struct{}
+
+func (d DummyTransport) Send(packet []byte) error {
+	return nil
+}

--- a/network/transport_test.go
+++ b/network/transport_test.go
@@ -1,0 +1,10 @@
+package network
+
+import "testing"
+
+func TestDummyTransport(t *testing.T) {
+	var tr Transport = DummyTransport{}
+	if err := tr.Send([]byte("data")); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/resource/allocator.go
+++ b/resource/allocator.go
@@ -1,0 +1,10 @@
+package resource
+
+// Allocator scales resources based on metrics.
+type Allocator interface {
+	Check() error
+}
+
+type DummyAllocator struct{}
+
+func (d DummyAllocator) Check() error { return nil }

--- a/resource/allocator_test.go
+++ b/resource/allocator_test.go
@@ -1,0 +1,10 @@
+package resource
+
+import "testing"
+
+func TestDummyAllocator(t *testing.T) {
+	var a Allocator = DummyAllocator{}
+	if err := a.Check(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/session/session.go
+++ b/session/session.go
@@ -1,0 +1,66 @@
+package session
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// Session represents a running emulator session.
+type Session struct {
+	ID       string
+	GameID   string
+	Endpoint string
+	Started  time.Time
+}
+
+type Manager interface {
+	Start(gameID string) (*Session, error)
+	Stop(id string) error
+	Get(id string) (*Session, error)
+}
+
+type InMemoryManager struct {
+	mu       sync.Mutex
+	sessions map[string]*Session
+}
+
+func NewInMemoryManager() *InMemoryManager {
+	return &InMemoryManager{sessions: make(map[string]*Session)}
+}
+
+func (m *InMemoryManager) Start(gameID string) (*Session, error) {
+	if gameID == "" {
+		return nil, errors.New("game id required")
+	}
+	s := &Session{
+		ID:       gameID + "_session",
+		GameID:   gameID,
+		Endpoint: "127.0.0.1:9000",
+		Started:  time.Now(),
+	}
+	m.mu.Lock()
+	m.sessions[s.ID] = s
+	m.mu.Unlock()
+	return s, nil
+}
+
+func (m *InMemoryManager) Stop(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.sessions[id]; !ok {
+		return errors.New("session not found")
+	}
+	delete(m.sessions, id)
+	return nil
+}
+
+func (m *InMemoryManager) Get(id string) (*Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[id]
+	if !ok {
+		return nil, errors.New("session not found")
+	}
+	return s, nil
+}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,21 @@
+package session
+
+import "testing"
+
+func TestInMemoryManager(t *testing.T) {
+	m := NewInMemoryManager()
+	s, err := m.Start("game1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.Get(s.ID)
+	if err != nil || got.GameID != "game1" {
+		t.Fatalf("expected game1, got %v, err %v", got, err)
+	}
+	if err := m.Stop(s.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Get(s.ID); err == nil {
+		t.Fatalf("expected error after stopping session")
+	}
+}

--- a/ui/orchestrator.go
+++ b/ui/orchestrator.go
@@ -1,0 +1,10 @@
+package ui
+
+// Orchestrator coordinates UI updates.
+type Orchestrator interface {
+	Notify(msg string) error
+}
+
+type DummyOrchestrator struct{}
+
+func (d DummyOrchestrator) Notify(msg string) error { return nil }

--- a/ui/orchestrator_test.go
+++ b/ui/orchestrator_test.go
@@ -1,0 +1,10 @@
+package ui
+
+import "testing"
+
+func TestDummyOrchestrator(t *testing.T) {
+	var o Orchestrator = DummyOrchestrator{}
+	if err := o.Notify("msg"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/video/encoder.go
+++ b/video/encoder.go
@@ -1,0 +1,12 @@
+package video
+
+// Encoder encodes raw frames.
+type Encoder interface {
+	Encode(frame []byte) ([]byte, error)
+}
+
+type DummyEncoder struct{}
+
+func (d DummyEncoder) Encode(frame []byte) ([]byte, error) {
+	return frame, nil
+}

--- a/video/encoder_test.go
+++ b/video/encoder_test.go
@@ -1,0 +1,11 @@
+package video
+
+import "testing"
+
+func TestDummyEncoder(t *testing.T) {
+	var e Encoder = DummyEncoder{}
+	out, err := e.Encode([]byte("frame"))
+	if err != nil || string(out) != "frame" {
+		t.Fatalf("unexpected encode result: %s %v", out, err)
+	}
+}


### PR DESCRIPTION
## Summary
- scaffold agent packages with basic interfaces and stub implementations
- expand server with login and session start endpoints using AuthenticationAgent and GameSessionManager
- add unit tests for agents and server

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684837749ea0832e92a63f74eadb96f9