### PR TITLE
Implement token refresh and session control

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The server listens on the port specified by the `PORT` environment variable (def
 
 - `/` – returns **Hello, world!**
 - `/health` – returns a JSON health status
-- `/session/start` – placeholder for starting a PS2 game session
+- `/login` – obtain an access and refresh token
+- `/refresh` – refresh an access token using a refresh token
+- `/session/start` – start a new game session
+- `/session/stop` – stop a running session
+- `/session/get?id=ID` – retrieve session metadata
 
 These endpoints will expand as the project grows toward streaming PS2 games through the cloud.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -45,10 +45,12 @@ func (s *SimpleAuth) Login(username, password string) (*Token, error) {
 func (s *SimpleAuth) Refresh(refreshToken string) (*Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, t := range s.tokens {
+	for k, t := range s.tokens {
 		if t.RefreshToken == refreshToken {
+			delete(s.tokens, k)
 			t.AccessToken = t.AccessToken + "_new"
 			t.ExpiresAt = time.Now().Add(time.Hour)
+			s.tokens[t.AccessToken] = t
 			return t, nil
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,21 @@ func setupRoutes(mux *http.ServeMux) {
 		json.NewEncoder(w).Encode(token)
 	})
 
+	mux.HandleFunc("/refresh", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			RefreshToken string `json:"refresh_token"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &req)
+		token, err := authAgent.Refresh(req.RefreshToken)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(token)
+	})
+
 	mux.HandleFunc("/session/start", func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
@@ -60,6 +75,50 @@ func setupRoutes(mux *http.ServeMux) {
 		body, _ := io.ReadAll(r.Body)
 		json.Unmarshal(body, &req)
 		s, err := sessionMgr.Start(req.GameID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(s)
+	})
+
+	mux.HandleFunc("/session/stop", func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		ok, _ := authAgent.Verify(authHeader)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var req struct {
+			SessionID string `json:"session_id"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &req)
+		if err := sessionMgr.Stop(req.SessionID); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/session/get", func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		ok, _ := authAgent.Verify(authHeader)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		id := r.URL.Query().Get("id")
+		s, err := sessionMgr.Get(id)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
## Summary
- support refreshing tokens in `SimpleAuth`
- extend README endpoint list
- add refresh and session control handlers
- test full session lifecycle

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6848390dc740832ea71d24c9c41992ea