### PR TITLE
Add backend interface for video module

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ The server listens on the port specified by the `PORT` environment variable (def
 - `/session/get?id=ID` – retrieve session metadata
 
 These endpoints will expand as the project grows toward streaming PS2 games through the cloud.
+
+## Video Module
+
+The `video` package now includes an extensible backend interface to hook up a PS2 emulator. `PCSX2Backend` launches a PCSX2 process, while `DummyBackend` is used for tests. Frame capture for PCSX2 is not yet implemented, but the interface provides the foundation for integrating real emulator output.
+

--- a/video/backend.go
+++ b/video/backend.go
@@ -1,0 +1,69 @@
+package video
+
+import (
+	"io"
+	"os/exec"
+)
+
+// Backend represents a running emulator that produces raw video frames.
+type Backend interface {
+	// Start launches the emulator process.
+	Start() error
+	// ReadFrame returns the next raw frame. io.EOF is returned when no frames remain.
+	ReadFrame() ([]byte, error)
+	// Stop terminates the emulator process.
+	Stop() error
+}
+
+// DummyBackend is a simple in-memory implementation used for tests.
+type DummyBackend struct {
+	frames [][]byte
+	idx    int
+}
+
+// NewDummyBackend creates a DummyBackend that will output the provided frames.
+func NewDummyBackend(frames [][]byte) *DummyBackend {
+	return &DummyBackend{frames: frames}
+}
+
+func (d *DummyBackend) Start() error { d.idx = 0; return nil }
+
+func (d *DummyBackend) ReadFrame() ([]byte, error) {
+	if d.idx >= len(d.frames) {
+		return nil, io.EOF
+	}
+	f := d.frames[d.idx]
+	d.idx++
+	return f, nil
+}
+
+func (d *DummyBackend) Stop() error { return nil }
+
+// PCSX2Backend launches a PCSX2 process. Frame capture integration is TBD.
+type PCSX2Backend struct {
+	exe string
+	iso string
+	cmd *exec.Cmd
+}
+
+// NewPCSX2Backend returns a new backend configured to run the given executable and ISO image.
+func NewPCSX2Backend(exe, iso string) *PCSX2Backend {
+	return &PCSX2Backend{exe: exe, iso: iso}
+}
+
+func (p *PCSX2Backend) Start() error {
+	p.cmd = exec.Command(p.exe, "--fullscreen", "--nogui", "--iso", p.iso)
+	return p.cmd.Start()
+}
+
+// ReadFrame currently returns io.EOF because frame capture is not yet implemented.
+func (p *PCSX2Backend) ReadFrame() ([]byte, error) {
+	return nil, io.EOF
+}
+
+func (p *PCSX2Backend) Stop() error {
+	if p.cmd != nil && p.cmd.Process != nil {
+		return p.cmd.Process.Kill()
+	}
+	return nil
+}

--- a/video/backend_test.go
+++ b/video/backend_test.go
@@ -1,0 +1,29 @@
+package video
+
+import (
+	"io"
+	"testing"
+)
+
+func TestDummyBackend(t *testing.T) {
+	frames := [][]byte{[]byte("a"), []byte("b")}
+	b := NewDummyBackend(frames)
+	if err := b.Start(); err != nil {
+		t.Fatal(err)
+	}
+	f1, err := b.ReadFrame()
+	if err != nil || string(f1) != "a" {
+		t.Fatalf("unexpected first frame %s %v", f1, err)
+	}
+	f2, err := b.ReadFrame()
+	if err != nil || string(f2) != "b" {
+		t.Fatalf("unexpected second frame %s %v", f2, err)
+	}
+	_, err = b.ReadFrame()
+	if err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+	if err := b.Stop(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `Backend` interface and `PCSX2Backend` stub to video module
- implement in-memory `DummyBackend` with unit test
- document the video backend setup in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68483bda1be8832e88ae893d11cb4f17